### PR TITLE
Fix `GLIBCXX_3.4.29' not found by mathplotlib

### DIFF
--- a/00_install.sh
+++ b/00_install.sh
@@ -56,6 +56,7 @@ if [ -e "$venv_dir" ]; then export PATH="$venv_dir/bin:$PATH"; fi
 echo "#!/bin/bash" >> env.sh
 echo "eval \"\$($mamba_bin shell hook --shell=bash)\"" >> env.sh
 echo "micromamba activate $venv_dir" >> env.sh
+echo "export LD_LIBRARY_PATH=$venv_dir/lib/:$LD_LIBRARY_PATH" >> env.sh
 source ./env.sh
 
 


### PR DESCRIPTION
prefer micromamba ./venv/lib rather than system /lib